### PR TITLE
Escape nested single quotes in echo command

### DIFF
--- a/docker/php/apache/Dockerfile
+++ b/docker/php/apache/Dockerfile
@@ -151,7 +151,7 @@ RUN sed -ri -e 's!DirectoryIndex index.php index.html!DirectoryIndex index.html 
 RUN { \
     echo '<Directory ${APACHE_DOCUMENT_ROOT}>'; \
     echo 'Header set Strict-Transport-Security "max-age=10886400; includeSubDomains"'; \
-    echo 'Header set Content-Security-Policy "default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests"'; \
+    echo 'Header set Content-Security-Policy "default-src \'self\';base-uri \'self\';font-src \'self\' https: data:;form-action \'self\';frame-ancestors \'self\';img-src \'self\' data:;object-src \'none\';script-src \'self\';script-src-attr \'none\';style-src \'self\' https: \'unsafe-inline\';upgrade-insecure-requests"'; \
     echo '</Directory>'; \
     } > /etc/apache2/conf-enabled/mod-rewrite.conf
 # Hide Apache Version and Linux OS From HTTP Headers


### PR DESCRIPTION
A proposal for #80 to fix various CSP header Firefox console warnings regarding missing single quotes around 'self' and 'none'